### PR TITLE
add Notification functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,16 @@ Check out [uv](https://docs.astral.sh/uv/)!
 
 ## Usage
 
+This module offers the following features:
+- [Menu](#menu) to display SwiftBar menus
+- [Notifications](#notification) to show notifications from a SwiftBar plugin
+
 Check out the features through basic examples below.
 
-### Basic menu
+
+### Menu
+
+#### Basic menu
 
 ```pycon
 >>> from swiftbarmenu import Menu
@@ -64,7 +71,7 @@ True
 'Item 1'
 ```
 
-### Multiple header
+#### Multiple header
 
 ```pycon
 >>> from swiftbarmenu import Menu
@@ -81,7 +88,7 @@ Header 3
 ---
 ```
 
-### Add parameters
+#### Add parameters
 
 You can add multiple [parameters](https://github.com/swiftbar/SwiftBar?tab=readme-ov-file#parameters):
 
@@ -105,7 +112,7 @@ Item 1|color=orange size=18 checked=True
 >>>
 ```
 
-### Add links
+#### Add links
 
 ```python
 >>> from swiftbarmenu import Menu
@@ -126,7 +133,7 @@ It's actually a shortcut for:
 GitHub|href=https://github.com
 ```
 
-### Nested items
+#### Nested items
 
 ```pycon
 >>> from swiftbarmenu import Menu
@@ -148,7 +155,7 @@ Item 1
 -- Item 1.3
 ```
 
-### Swift icons
+#### Swift icons
 
 You can add [SF Symbols](https://developer.apple.com/sf-symbols/) using `:symbol:` syntax
 
@@ -172,7 +179,7 @@ Cloudy! :cloud.rain:|sfcolor=blue
 
 Search _sf symbols_ [here](https://hotpot.ai/free-icons).
 
-### Add images
+#### Add images
 
 It's pretty simple to add an image (**using path not base64**) to a menu item:
 
@@ -194,7 +201,7 @@ It's actually a shortcut for:
 > [!TIP]
 > 💡 16x16 pixels is a nice size for menu images.
 
-### Add separators
+#### Add separators
 
 A separator is a thin long line on the menu:
 
@@ -224,7 +231,7 @@ You can explicitly add a separator using:
 ---
 ```
 
-### Add actions
+#### Add actions
 
 Add action items to the Menu, when clicked a script will be invoked with the provided params:
 
@@ -244,7 +251,7 @@ Test action...|bash=/usr/local/swiftbar_plugins/test_plugin.1h.py param0=test re
 > [!NOTE]
 > By default, this action will execute the current plugin script (if one is not specified using the `bash` parameter) in background passing the provided parameters.
 
-#### Custom script
+##### Custom script
 
 Pass `bash` parameter to customize the script to be executed:
 
@@ -260,7 +267,7 @@ My menu
 Echo action...|bash=/bin/echo param0=test refresh=false terminal=false
 ```
 
-#### Nested actions
+##### Nested actions
 
 Action items can also be nested inside other Menu items:
 
@@ -278,7 +285,7 @@ Item 1
 -- Test action...|bash=/usr/local/swiftbar_plugins/test_plugin.1h.py param0=test refresh=false terminal=false
 ```
 
-### Add "Refresh" action
+#### Add "Refresh" action
 
 Add a "Refresh..." action to the Menu, when clicked a refresh of the plugin will be triggered
 
@@ -309,7 +316,7 @@ Reload|refresh=true terminal=false
 > [!NOTE]
 > This action will only refresh the current plugin, not all installed plugins.
 
-### Access header and body
+#### Access header and body
 
 Within the menu, you can access the header and the body:
 
@@ -368,7 +375,7 @@ Item 1.3
 Item 1.3
 ```
 
-### Clear items
+#### Clear items
 
 You can clear whole menu:
 
@@ -431,6 +438,42 @@ My menu
 ---
 Item 1
 ```
+
+
+### Notification
+
+#### Basic usage
+
+To create and show notifications from a SwiftBar plugin, do the following:
+
+```pycon
+>>> from swiftbarmenu import Notification
+
+>>> n = Notification("Title", "Subtitle", "Body", "https://example.com")
+
+>>> n.show()
+Notification(title='Title', subtitle='Subtitle', body='Body', href='https://example.com')
+
+>>> n
+Notification(title='Title', subtitle='Subtitle', body='Body', href='https://example.com')
+```
+
+> [!NOTE]
+> All parameters except for `title` are optional.
+
+#### Silent notifications
+
+To trigger notifications without sound, just pass the `silent` parameter to `.show()` method
+
+```pycon
+>>> from swiftbarmenu import Notification
+
+>>> n = Notification("Title", "Subtitle", "Body", "https://example.com")
+
+>>> n.show(True) # pass True to show silently
+Notification(title='Title', subtitle='Subtitle', body='Body', href='https://example.com')
+```
+
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Search _sf symbols_ [here](https://hotpot.ai/free-icons).
 It's pretty simple to add an image (**using path not base64**) to a menu item:
 
 ```pycon
->>> from src.swiftbarmenu import Menu
+>>> from swiftbarmenu import Menu
 
 >>> m = Menu('My menu')
 
@@ -290,7 +290,7 @@ Item 1
 Add a "Refresh..." action to the Menu, when clicked a refresh of the plugin will be triggered
 
 ```pycon
->>> from src.swiftbarmenu import Menu
+>>> from swiftbarmenu import Menu
 
 >>> m = Menu('My menu')
 >>> m.add_action_refresh()
@@ -321,7 +321,7 @@ Reload|refresh=true terminal=false
 Within the menu, you can access the header and the body:
 
 ```pycon
->>> from src.swiftbarmenu import Menu
+>>> from swiftbarmenu import Menu
 
 >>> m = Menu('My menu')
 >>> m.add_header('Header 2')
@@ -359,7 +359,7 @@ True
 Even with nested items:
 
 ```pycon
->>> from src.swiftbarmenu import Menu
+>>> from swiftbarmenu import Menu
 
 >>> m = Menu('My menu')
 
@@ -380,7 +380,7 @@ Item 1.3
 You can clear whole menu:
 
 ```pycon
->>> from src.swiftbarmenu import Menu
+>>> from swiftbarmenu import Menu
 
 >>> m = Menu('My menu')
 >>> m.add_header('Header 2')
@@ -412,7 +412,7 @@ Item 2
 You can also clear nested items for a certain item:
 
 ```pycon
->>> from src.swiftbarmenu import Menu
+>>> from swiftbarmenu import Menu
 
 >>> m = Menu('My menu')
 >>> item1 = m.add_item('Item 1')

--- a/README.md
+++ b/README.md
@@ -566,32 +566,32 @@ A VS Code instance opens in your browser (or local VS Code) connected to the pre
 
 Releases use [Semantic Versioning](https://semver.org/) (`<major>.<minor>.<patch>`).
 
-## 0.1.4
+### 0.1.4
 
 Released 2025-04-08
 
 - Add development tooling (Dev Containers, Dependabot, GH Actions) via [pull request #1](https://github.com/sdelquin/swiftbarmenu/pull/1) (kudos to [`@panz3r`](https://github.com/panz3r)).
 - Add action items via [pull request #2](https://github.com/sdelquin/swiftbarmenu/pull/2) (kudos to [`@panz3r`](https://github.com/panz3r)).
 
-## 0.1.3
+### 0.1.3
 
 Released 2025-03-08
 
 - Add Mypy compatibility.
 
-## 0.1.2
+### 0.1.2
 
 Released 2025-02-28
 
 - Add feature to include images using path.
 
-## 0.1.1
+### 0.1.1
 
 Released 2025-02-27
 
 - Fixes menus with no header.
 
-## 0.1.0
+### 0.1.0
 
 Released 2025-02-26
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,18 +5,18 @@ build-backend = "hatchling.build"
 [project]
 name = "swiftbarmenu"
 version = "0.1.4"
-license = { file = "LICENSE" }
 dependencies = []
+requires-python = ">=3.9"
 authors = [
-    { email = "sdelquin@gmail.com" },
-    { name = "Sergio Delgado Quintero" },
+    { name = "Sergio Delgado Quintero", email = "sdelquin@gmail.com" }
 ]
 maintainers = [
-    { name = "Sergio Delgado Quintero", email = "sdelquin@gmail.com" },
+    { name = "Sergio Delgado Quintero", email = "sdelquin@gmail.com" }
 ]
 description = "Easy menu building for SwiftBar (... and xbar)"
 readme = "README.md"
-requires-python = ">=3.9"
+license = "MIT"
+license-files = ["LICEN[CS]E*"]
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",
@@ -26,6 +26,7 @@ classifiers = [
 [project.urls]
 homepage = "https://github.com/sdelquin/swiftbarmenu"
 repository = "https://github.com/sdelquin/swiftbarmenu"
+issues = "https://github.com/sdelquin/swiftbarmenu/issues"
 
 [tool.pytest.ini_options]
 pythonpath = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ maintainers = [
 ]
 description = "Easy menu building for SwiftBar (... and xbar)"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.9"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,4 +2,5 @@ build
 twine
 pytest
 pytest-cov
+pytest-mock
 ipython

--- a/src/swiftbarmenu/__init__.py
+++ b/src/swiftbarmenu/__init__.py
@@ -1,1 +1,2 @@
 from .menu import Menu, MenuItem  # noqa
+from .notification import Notification  # noqa

--- a/src/swiftbarmenu/notification.py
+++ b/src/swiftbarmenu/notification.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import os
+from os.path import basename
+import sys
+from urllib.parse import urlencode, quote
+
+
+class Notification:
+    def __init__(self, title: str, subtitle=None, body=None, href=None):
+        self.title = title
+        self.subtitle = subtitle
+        self.body = body
+        self.href = href
+
+    def show(self, silent=False) -> Notification:
+        plugin_path = os.getenv("SWIFTBAR_PLUGIN_PATH", sys.argv[0])
+        plugin_name = basename(plugin_path)
+
+        payload = {
+            "plugin":   plugin_name,     # required
+            "title":    self.title,      # required
+            "subtitle": self.subtitle,
+            "body":     self.body,
+            "href":     self.href,
+            "silent":   "true" if silent else None
+        }
+
+        notification_payload = dict(
+            filter(lambda item: item[1] is not None, payload.items())
+        )
+
+        # Format parameters for query
+        query = urlencode(notification_payload, quote_via=quote)
+
+        # Trigger notification through SwiftBar
+        os.system("open -g 'swiftbar://notify?%s'" % query)
+
+        return self

--- a/src/swiftbarmenu/notification.py
+++ b/src/swiftbarmenu/notification.py
@@ -37,3 +37,9 @@ class Notification:
         os.system("open -g 'swiftbar://notify?%s'" % query)
 
         return self
+
+    def __repr__(self):
+        return self.__str__()
+
+    def __str__(self):
+        return f"Notification(title='{self.title}', subtitle='{self.subtitle}', body='{self.body}', href='{self.href}')"

--- a/tests/sbm.py
+++ b/tests/sbm.py
@@ -1,15 +1,37 @@
 import sys
 
 sys.path.append('.')
-from src.swiftbarmenu import Menu
 
-m = Menu('Test')
-m.add_item('Item 1')
-m.add_image('tests/images/parrot.png', 'Parrot')
-item2 = m.add_item('Item 2', sep=True, checked=True)
-item2.add_item('Subitem 1')
-item2.add_item('Subitem 2')
-m.add_link('Item 3', 'https://example.com', color='yellow')
-m.add_item(':thermometer: Item 4', color='orange', sfcolor='black', sfsize=20)
+from src.swiftbarmenu import Menu, Notification
 
-m.dump()
+
+def main():
+    m = Menu('Test')
+
+    m.add_item('Item 1')
+
+    m.add_image('tests/images/parrot.png', 'Parrot')
+
+    item2 = m.add_item('Item 2', sep=True, checked=True)
+    item2.add_item('Subitem 1')
+    item2.add_item('Subitem 2')
+
+    m.add_link('Item 3', 'https://example.com', color='yellow')
+
+    m.add_item(':thermometer: Item 4', color='orange', sfcolor='black', sfsize=20)
+
+    m.add_action('Notification...', ['show-notification'], sep=True)
+
+    m.add_action_refresh(sep=True)
+
+    m.dump()
+
+
+def show_notification():
+    Notification("Test notification", "This is a test Notification", "Click on the banner to open 'swiftbarmenu' GitHub repository", "https://github.com/sdelquin/swiftbarmenu").show()
+
+
+if len(sys.argv) == 2 and sys.argv[1] == 'show-notification':
+    show_notification()
+else:
+    main()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,4 +1,3 @@
-import os
 import pytest
 
 from src.swiftbarmenu import Menu, MenuItem

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -1,0 +1,115 @@
+import os
+
+from src.swiftbarmenu import Notification
+
+
+def test_notification_full(mocker, monkeypatch):
+    # Arrange
+    monkeypatch.setenv('SWIFTBAR_PLUGIN_PATH',
+                       '/usr/local/swiftbar_plugins/test_plugin.1h.py')
+    mocker.patch('os.system', return_value=None)
+
+    # Act
+    Notification('Title', 'Subtitle', 'Body', 'https://example.com').show()
+
+    # Assert
+    os.system.assert_called_once_with(
+        "open -g 'swiftbar://notify?plugin=test_plugin.1h.py&title=Title&subtitle=Subtitle&body=Body&href=https%3A%2F%2Fexample.com'")
+
+
+def test_notification_full_silent(mocker, monkeypatch):
+    # Arrange
+    monkeypatch.setenv('SWIFTBAR_PLUGIN_PATH',
+                       '/usr/local/swiftbar_plugins/test_plugin.1h.py')
+    mocker.patch('os.system', return_value=None)
+
+    # Act
+    Notification('Title', 'Subtitle', 'Body', 'https://example.com').show(True)
+
+    # Assert
+    os.system.assert_called_once_with(
+        "open -g 'swiftbar://notify?plugin=test_plugin.1h.py&title=Title&subtitle=Subtitle&body=Body&href=https%3A%2F%2Fexample.com&silent=true'")
+
+
+def test_notification_simple(mocker, monkeypatch):
+    # Arrange
+    monkeypatch.setenv('SWIFTBAR_PLUGIN_PATH',
+                       '/usr/local/swiftbar_plugins/test_plugin.1h.py')
+    mocker.patch('os.system', return_value=None)
+
+    # Act
+    Notification('Title').show()
+
+    # Assert
+    os.system.assert_called_once_with(
+        "open -g 'swiftbar://notify?plugin=test_plugin.1h.py&title=Title'")
+
+
+def test_notification_simple_silent(mocker, monkeypatch):
+    # Arrange
+    monkeypatch.setenv('SWIFTBAR_PLUGIN_PATH',
+                       '/usr/local/swiftbar_plugins/test_plugin.1h.py')
+    mocker.patch('os.system', return_value=None)
+
+    # Act
+    Notification('Title').show(True)
+
+    # Assert
+    os.system.assert_called_once_with(
+        "open -g 'swiftbar://notify?plugin=test_plugin.1h.py&title=Title&silent=true'")
+
+
+def test_notification_with_body(mocker, monkeypatch):
+    # Arrange
+    monkeypatch.setenv('SWIFTBAR_PLUGIN_PATH',
+                       '/usr/local/swiftbar_plugins/test_plugin.1h.py')
+    mocker.patch('os.system', return_value=None)
+
+    # Act
+    Notification('Title', body="This is a notification content").show()
+
+    # Assert
+    os.system.assert_called_once_with(
+        "open -g 'swiftbar://notify?plugin=test_plugin.1h.py&title=Title&body=This%20is%20a%20notification%20content'")
+
+
+def test_notification_with_body_silent(mocker, monkeypatch):
+    # Arrange
+    monkeypatch.setenv('SWIFTBAR_PLUGIN_PATH',
+                       '/usr/local/swiftbar_plugins/test_plugin.1h.py')
+    mocker.patch('os.system', return_value=None)
+
+    # Act
+    Notification('Title', body="This is a notification content").show(True)
+
+    # Assert
+    os.system.assert_called_once_with(
+        "open -g 'swiftbar://notify?plugin=test_plugin.1h.py&title=Title&body=This%20is%20a%20notification%20content&silent=true'")
+
+
+def test_notification_with_link(mocker, monkeypatch):
+    # Arrange
+    monkeypatch.setenv('SWIFTBAR_PLUGIN_PATH',
+                       '/usr/local/swiftbar_plugins/test_plugin.1h.py')
+    mocker.patch('os.system', return_value=None)
+
+    # Act
+    Notification('Title', href="https://example.com").show()
+
+    # Assert
+    os.system.assert_called_once_with(
+        "open -g 'swiftbar://notify?plugin=test_plugin.1h.py&title=Title&href=https%3A%2F%2Fexample.com'")
+
+
+def test_notification_with_link_silent(mocker, monkeypatch):
+    # Arrange
+    monkeypatch.setenv('SWIFTBAR_PLUGIN_PATH',
+                       '/usr/local/swiftbar_plugins/test_plugin.1h.py')
+    mocker.patch('os.system', return_value=None)
+
+    # Act
+    Notification('Title', href="https://example.com").show(True)
+
+    # Assert
+    os.system.assert_called_once_with(
+        "open -g 'swiftbar://notify?plugin=test_plugin.1h.py&title=Title&href=https%3A%2F%2Fexample.com&silent=true'")

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -3,6 +3,18 @@ import os
 from src.swiftbarmenu import Notification
 
 
+def test_notification_str():
+    n = Notification('Title', 'Subtitle', 'Body', 'https://example.com')
+
+    assert n.__str__() == "Notification(title='Title', subtitle='Subtitle', body='Body', href='https://example.com')"
+
+
+def test_notification_repr():
+    n = Notification('Title', 'Subtitle', 'Body', 'https://example.com')
+
+    assert n.__repr__() == "Notification(title='Title', subtitle='Subtitle', body='Body', href='https://example.com')"
+
+
 def test_notification_full(mocker, monkeypatch):
     # Arrange
     monkeypatch.setenv('SWIFTBAR_PLUGIN_PATH',


### PR DESCRIPTION
## Motivation

This PR introduces a new `Notification` class to provide a standardized and flexible way for plugins to display messages or notifications to the user.

## Description of Changes

This PR introduces a new `Notification` feature and includes related updates:

* **Feature Implementation:**
    * Implemented the core `Notification` class.

* **Testing:**
    * Added comprehensive unit tests for the new `Notification` class and its methods using `pytest`.
    * Introduced `pytest-mock` as a new development dependency to facilitate testing.
    * Updated the `sbm.py` test plugin to showcase the usage of the new `Notification` feature.
    * Performed minor cleanup on existing test imports.

* **Documentation:**
    * Added a new "Notification" section to the README.
    * Updated usage examples in the documentation.
    * Updated the "Changelog" section.

* **Configuration & Fixes:**
    * Lowered the minimum required Python version to `3.9` to allow the module to work on standard macOS installations without requiring users to perform extra Python installation steps (as of macOS 15.4 the default installed version is `3.9.6`).
    * Updated `pyproject.toml`, fixed and sorted entries based on [official Python documentation](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#about-your-project).

## How to Test

1.  Ensure all automated tests pass: `just test` and `just cov`
2.  Review the new "Notification" section in the README and the updated usage examples for clarity and correctness.
3.  *(Optional)* Manually trigger the functionality in the `sbm.py` test plugin (if easily runnable) to observe the notification output.
4.  Verify the package installs and runs correctly on Python 3.9, especially on a macOS system.

## Checklist

* [x] My code follows the project's style guidelines.
* [x] I have added tests that prove that my feature works.
* [x] I have updated the necessary documentation.
* [x] All new and existing tests passed.
* [x] I have performed a self-review of my own code.

## Notes for Reviewers

* This PR lowers the minimum required Python version to 3.9, primarily to improve compatibility with default macOS environments.
* Adds `pytest-mock` as a development dependency.
