### PR TITLE
feat: implement `Persistence` feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ This module offers the following features:
 
 - [Menu](#menu) to display SwiftBar menus
 - [Notifications](#notification) to show notifications from a SwiftBar plugin
+- [Persistence](#persistence) to store and load data for a SwiftBar plugin
 
 Check out the features through basic examples below.
 
@@ -471,6 +472,58 @@ To trigger notifications without sound, just pass the `silent` parameter to `.sh
 
 >>> n.show(True) # pass True to show silently
 Notification(title='Title', subtitle='Subtitle', body='Body', href='https://example.com')
+```
+
+## Persistence
+
+### Basic usage
+
+To store (and later load) data for a SwiftBar plugin, do the following:
+
+```pycon
+>>> from swiftbarmenu import Persistence
+
+>>> sample_data = {
+    "data": "test",
+    "nested": {
+        "data1": "test",
+        "data2": "test"
+    }
+}
+
+>>> p = Persistence()
+>>> p.save(sample_data)
+
+>>> stored_data = p.load()
+>>> store_data
+{'data': 'test', 'nested': {'data1': 'test', 'data2': 'test'}}
+```
+
+> [!NOTE]
+> `.save()` method supports a `dict[str, Any]` as input and the data are stored using the [`pickle`](https://docs.python.org/3/library/pickle.html) module internally.
+
+
+### Custom file name
+
+To store (and later load) data for a SwiftBar plugin with a specific name, do the following:
+
+```pycon
+>>> from swiftbarmenu import Persistence
+
+>>> sample_data = {
+    "data": "test",
+    "nested": {
+        "data1": "test",
+        "data2": "test"
+    }
+}
+
+>>> p = Persistence("example")
+>>> p.save(sample_data)
+
+>>> stored_data = p.load()
+>>> store_data
+{'data': 'test', 'nested': {'data1': 'test', 'data2': 'test'}}
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -495,8 +495,14 @@ To store (and later load) data for a SwiftBar plugin, do the following:
 >>> p.save(sample_data)
 
 >>> stored_data = p.load()
->>> store_data
+>>> stored_data
 {'data': 'test', 'nested': {'data1': 'test', 'data2': 'test'}}
+
+>>> p.clear()
+
+>>> stored_data = p.load()
+>>> stored_data
+{}
 ```
 
 > [!NOTE]
@@ -522,8 +528,14 @@ To store (and later load) data for a SwiftBar plugin with a specific name, do th
 >>> p.save(sample_data)
 
 >>> stored_data = p.load()
->>> store_data
+>>> stored_data
 {'data': 'test', 'nested': {'data1': 'test', 'data2': 'test'}}
+
+>>> p.clear()
+
+>>> stored_data = p.load()
+>>> stored_data
+{}
 ```
 
 ## Development

--- a/src/swiftbarmenu/__init__.py
+++ b/src/swiftbarmenu/__init__.py
@@ -1,2 +1,3 @@
 from .menu import Menu, MenuItem  # noqa
 from .notification import Notification  # noqa
+from .persistence import Persistence  # noqa

--- a/src/swiftbarmenu/persistence.py
+++ b/src/swiftbarmenu/persistence.py
@@ -40,6 +40,11 @@ class Persistence:
         with self.file_path.open('rb') as file:
             return pickle.load(file)
 
+    def clear(self) -> None:
+        """Remove the data file if it exists."""
+        if self.file_path.exists():
+            self.file_path.unlink()
+
     def __repr__(self):
         return self.__str__()
 

--- a/src/swiftbarmenu/persistence.py
+++ b/src/swiftbarmenu/persistence.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import os
+import pickle
+from pathlib import Path
+from typing import Any
+
+
+class Persistence:
+    def __init__(self, file_name: str = "data"):
+        """Initialize Persistence with a file name.
+
+        Args:
+            file_name: Name of the data file to save/load
+        """
+
+        self.file_path = Path(
+            os.getenv('SWIFTBAR_PLUGIN_DATA_PATH', '.'),
+            f'{file_name}.pkl'
+        )
+
+    def save(self, data: dict[str, Any]) -> None:
+        """Save data to a file using pickle.
+
+        Args:
+            data: Dictionary containing the data to save
+        """
+        with self.file_path.open('wb') as file:
+            pickle.dump(data, file)
+
+    def load(self) -> dict[str, Any]:
+        """Load data from a file using pickle.
+
+        Returns:
+            Dictionary containing the loaded data
+        """
+        if not self.file_path.exists():
+            return {}
+
+        with self.file_path.open('rb') as file:
+            return pickle.load(file)
+
+    def __repr__(self):
+        return self.__str__()
+
+    def __str__(self):
+        return (
+            f"Persistence("
+            f"file_name='{self.file_path.stem}', "
+            f"path='{self.file_path}'"
+            f")"
+        )

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1,0 +1,149 @@
+import pickle
+
+from src.swiftbarmenu import Persistence
+
+
+def test_persistence_str():
+    p = Persistence()
+
+    assert p.__str__() == "Persistence(file_name='data', path='data.pkl')"
+
+
+def test_persistence_repr():
+    p = Persistence()
+
+    assert p.__repr__() == "Persistence(file_name='data', path='data.pkl')"
+
+
+def test_persistence_save(monkeypatch, tmp_path):
+    # Arrange
+    plugin_data_p = tmp_path / "test.1h.py"
+    plugin_data_p.mkdir()
+
+    monkeypatch.setenv('SWIFTBAR_PLUGIN_DATA_PATH', plugin_data_p.as_posix())
+    monkeypatch.setenv('SWIFTBAR_PLUGIN_PATH', '/sbm/plugins/test.1h.py')
+
+    sample_data = {
+        "name": "test",
+        "data": {
+            "data1": "test",
+            "data2": "test"
+        }
+    }
+
+    # Act
+    p = Persistence()
+    p.save(sample_data)
+
+    # Assert
+    with (plugin_data_p / "data.pkl").open('rb') as file:
+        stored_data = pickle.load(file)
+
+        assert stored_data == sample_data
+
+
+def test_persistence_load(monkeypatch, tmp_path):
+    # Arrange
+    plugin_data_p = tmp_path / "test.1h.py"
+    plugin_data_p.mkdir()
+
+    monkeypatch.setenv('SWIFTBAR_PLUGIN_DATA_PATH', plugin_data_p.as_posix())
+    monkeypatch.setenv('SWIFTBAR_PLUGIN_PATH', '/sbm/plugins/test.1h.py')
+
+    sample_data = {
+        "name": "test 2",
+        "data": "test",
+    }
+
+    with (plugin_data_p / "data.pkl").open('wb') as file:
+        stored_data = pickle.dump(sample_data, file)
+
+    # Act
+    p = Persistence()
+    stored_data = p.load()
+
+    # Assert
+    assert stored_data == sample_data
+
+
+def test_persistence_load_nofile(monkeypatch, tmp_path):
+    # Arrange
+    plugin_data_p = tmp_path / "test.1h.py"
+    plugin_data_p.mkdir()
+
+    monkeypatch.setenv('SWIFTBAR_PLUGIN_DATA_PATH', plugin_data_p.as_posix())
+    monkeypatch.setenv('SWIFTBAR_PLUGIN_PATH', '/sbm/plugins/test.1h.py')
+
+    # Act
+    p = Persistence()
+    stored_data = p.load()
+
+    # Assert
+    assert stored_data == {}
+
+
+def test_persistence_save_custom_name(monkeypatch, tmp_path):
+    # Arrange
+    plugin_data_p = tmp_path / "test.1h.py"
+    plugin_data_p.mkdir()
+
+    monkeypatch.setenv('SWIFTBAR_PLUGIN_DATA_PATH', plugin_data_p.as_posix())
+    monkeypatch.setenv('SWIFTBAR_PLUGIN_PATH', '/sbm/plugins/test.1h.py')
+
+    sample_data = {
+        "name": "test",
+        "data": {
+            "data1": "test",
+            "data2": "test"
+        }
+    }
+
+    # Act
+    p = Persistence("test")
+    p.save(sample_data)
+
+    # Assert
+    with (plugin_data_p / "test.pkl").open('rb') as file:
+        stored_data = pickle.load(file)
+
+        assert stored_data == sample_data
+
+
+def test_persistence_load_custom_name(monkeypatch, tmp_path):
+    # Arrange
+    plugin_data_p = tmp_path / "test.1h.py"
+    plugin_data_p.mkdir()
+
+    monkeypatch.setenv('SWIFTBAR_PLUGIN_DATA_PATH', plugin_data_p.as_posix())
+    monkeypatch.setenv('SWIFTBAR_PLUGIN_PATH', '/sbm/plugins/test.1h.py')
+
+    sample_data = {
+        "name": "test 2",
+        "data": "test",
+    }
+
+    with (plugin_data_p / "test.pkl").open('wb') as file:
+        stored_data = pickle.dump(sample_data, file)
+
+    # Act
+    p = Persistence("test")
+    stored_data = p.load()
+
+    # Assert
+    assert stored_data == sample_data
+
+
+def test_persistence_load_custom_name_nofile(monkeypatch, tmp_path):
+    # Arrange
+    plugin_data_p = tmp_path / "test.1h.py"
+    plugin_data_p.mkdir()
+
+    monkeypatch.setenv('SWIFTBAR_PLUGIN_DATA_PATH', plugin_data_p.as_posix())
+    monkeypatch.setenv('SWIFTBAR_PLUGIN_PATH', '/sbm/plugins/test.1h.py')
+
+    # Act
+    p = Persistence("test")
+    stored_data = p.load()
+
+    # Assert
+    assert stored_data == {}

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -82,6 +82,30 @@ def test_persistence_load_nofile(monkeypatch, tmp_path):
     assert stored_data == {}
 
 
+def test_persistence_clear(monkeypatch, tmp_path):
+    # Arrange
+    plugin_data_p = tmp_path / "test.1h.py"
+    plugin_data_p.mkdir()
+
+    monkeypatch.setenv('SWIFTBAR_PLUGIN_DATA_PATH', plugin_data_p.as_posix())
+    monkeypatch.setenv('SWIFTBAR_PLUGIN_PATH', '/sbm/plugins/test.1h.py')
+
+    sample_data = {
+        "data": "test",
+    }
+
+    p = Persistence()
+    p.save(sample_data)
+
+    assert (plugin_data_p / "data.pkl").exists()
+
+    # Act
+    p.clear()
+
+    # Assert
+    assert not (plugin_data_p / "data.pkl").exists()
+
+
 def test_persistence_save_custom_name(monkeypatch, tmp_path):
     # Arrange
     plugin_data_p = tmp_path / "test.1h.py"
@@ -147,3 +171,27 @@ def test_persistence_load_custom_name_nofile(monkeypatch, tmp_path):
 
     # Assert
     assert stored_data == {}
+
+
+def test_persistence_clear_custom_name(monkeypatch, tmp_path):
+    # Arrange
+    plugin_data_p = tmp_path / "test.1h.py"
+    plugin_data_p.mkdir()
+
+    monkeypatch.setenv('SWIFTBAR_PLUGIN_DATA_PATH', plugin_data_p.as_posix())
+    monkeypatch.setenv('SWIFTBAR_PLUGIN_PATH', '/sbm/plugins/test.1h.py')
+
+    sample_data = {
+        "data": "test",
+    }
+
+    p = Persistence("test")
+    p.save(sample_data)
+
+    assert (plugin_data_p / "test.pkl").exists()
+
+    # Act
+    p.clear()
+
+    # Assert
+    assert not (plugin_data_p / "test.pkl").exists()


### PR DESCRIPTION
## Motivation

This PR introduces a `Persistence` class to enable the saving and loading of plugin data between sessions, allowing for stateful behaviors.

## Description of Changes

This PR introduces data persistence functionality:

* **Feature Implementation:**
    * Implemented the initial `Persistence` class to manage data saving and loading using [`pickle`](https://docs.python.org/3.9/library/pickle.html?highlight=pickle#module-pickle) built-in module to store files in plugin data directory.

* **Testing:**
    * Added unit tests covering data saving and loading scenarios.

* **Documentation:**
    * Added a new "Persistence" section to the README.

**How to Test:**

1.  Ensure all automated tests pass: `just test` and `just cov`
2.  Review the "Persistence" section in the README for clarity and accuracy.
3.  *(Optional but recommended)* Manually test the persistence flow:
    * Run the test plugin.
    * Perform actions that should trigger data saving via the `Persistence` class.
    * Refresh the plugin.
    * Verify that the previously saved data is correctly loaded and reflected in the plugin's state/UI.

**Checklist:**

* [x] My code follows the project's style guidelines.
* [x] I have added tests that prove my fix is effective or that my feature works.
* [x] I have updated the necessary documentation.
* [x] All new and existing tests passed.
* [x] I have performed a self-review of my own code.

**Notes for Reviewers:**

* The `Persistence` feature is not meant to be used for plugin configurations but for generic state data saving. I'm already working on a dedicated feature for configuration management based on [`configparser`](https://docs.python.org/3.9/library/configparser.html) module 😬 
